### PR TITLE
feat: set worker_definitions.parameters as :map

### DIFF
--- a/lib/step_flow/migrations/all.ex
+++ b/lib/step_flow/migrations/all.ex
@@ -43,5 +43,11 @@ defmodule StepFlow.Migration.All do
       20_200_130_170_300,
       StepFlow.Migration.CreateProgressions
     )
+
+    Ecto.Migrator.up(
+      StepFlow.Repo,
+      20_201_020_140_300,
+      StepFlow.Migration.ModifyWorkerDefinitionsParametersType
+    )
   end
 end

--- a/lib/step_flow/migrations/modify_worker_definitions_parameters_type.ex
+++ b/lib/step_flow/migrations/modify_worker_definitions_parameters_type.ex
@@ -1,20 +1,19 @@
 defmodule StepFlow.Migration.ModifyWorkerDefinitionsParametersType do
-    use Ecto.Migration
-    @moduledoc false
-  
-    def change do
-        drop_if_exists table(:step_flow_worker_definitions)
+  use Ecto.Migration
+  @moduledoc false
 
-        create table(:step_flow_worker_definitions) do
-            add(:queue_name, :string)
-            add(:label, :string)
-            add(:version, :string)
-            add(:short_description, :string)
-            add(:description, :text)
-            add(:parameters, :map, default: %{})
-      
-            timestamps()
-        end
+  def change do
+    drop_if_exists(table(:step_flow_worker_definitions))
+
+    create table(:step_flow_worker_definitions) do
+      add(:queue_name, :string)
+      add(:label, :string)
+      add(:version, :string)
+      add(:short_description, :string)
+      add(:description, :text)
+      add(:parameters, :map, default: %{})
+
+      timestamps()
     end
   end
-  
+end

--- a/lib/step_flow/migrations/modify_worker_definitions_parameters_type.ex
+++ b/lib/step_flow/migrations/modify_worker_definitions_parameters_type.ex
@@ -1,0 +1,15 @@
+defmodule StepFlow.Migration.ModifyWorkerDefinitionsParametersType do
+    use Ecto.Migration
+    @moduledoc false
+  
+    def change do
+        alter table(:step_flow_worker_definitions) do
+            remove(:parameters)
+        end
+
+        alter table(:step_flow_worker_definitions) do
+            add(:parameters, :map)
+        end
+    end
+  end
+  

--- a/lib/step_flow/migrations/modify_worker_definitions_parameters_type.ex
+++ b/lib/step_flow/migrations/modify_worker_definitions_parameters_type.ex
@@ -3,12 +3,17 @@ defmodule StepFlow.Migration.ModifyWorkerDefinitionsParametersType do
     @moduledoc false
   
     def change do
-        alter table(:step_flow_worker_definitions) do
-            remove(:parameters)
-        end
+        drop_if_exists table(:step_flow_worker_definitions)
 
-        alter table(:step_flow_worker_definitions) do
-            add(:parameters, :map)
+        create table(:step_flow_worker_definitions) do
+            add(:queue_name, :string)
+            add(:label, :string)
+            add(:version, :string)
+            add(:short_description, :string)
+            add(:description, :text)
+            add(:parameters, :map, default: %{})
+      
+            timestamps()
         end
     end
   end


### PR DESCRIPTION
Fixes #66

Create a migration to set worker_definitions.parameters as :map:

1. remove parameters column
2. add parameters column as map