### PR TITLE
hotfix: retry a message with no queue has no progression

### DIFF
--- a/lib/step_flow/workflows/workflows.ex
+++ b/lib/step_flow/workflows/workflows.ex
@@ -373,7 +373,7 @@ defmodule StepFlow.Workflows do
           count
 
         {:retrying, []} ->
-          count
+          count + 1
 
         {:retrying, _} ->
           last_progression = job.progressions |> Progression.get_last_progression()

--- a/lib/step_flow/workflows/workflows.ex
+++ b/lib/step_flow/workflows/workflows.ex
@@ -372,6 +372,9 @@ defmodule StepFlow.Workflows do
         {nil, _} ->
           count
 
+        {:retrying, []} ->
+          count
+
         {:retrying, _} ->
           last_progression = job.progressions |> Progression.get_last_progression()
           last_status = job.status |> Status.get_last_status()

--- a/test/run_workflows/status_step_test.exs
+++ b/test/run_workflows/status_step_test.exs
@@ -3,6 +3,7 @@ defmodule StepFlow.RunWorkflows.StatusStepTest do
   use Plug.Test
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias StepFlow.Repo
   alias StepFlow.Step
 
   doctest StepFlow
@@ -72,6 +73,15 @@ defmodule StepFlow.RunWorkflows.StatusStepTest do
       assert StepFlow.HelpersTest.get_job_count_status(workflow, 1).queued == 1
 
       StepFlow.HelpersTest.check(workflow.id, 1, 1)
+      StepFlow.HelpersTest.change_job_status(workflow, 1, :retrying)
+
+      :timer.sleep(1000)
+
+      {:ok, "still_processing"} = Step.start_next(workflow)
+
+      assert StepFlow.HelpersTest.get_job_count_status(workflow, 1).queued == 1
+      assert StepFlow.HelpersTest.get_job_count_status(workflow, 1).processing == 0
+
       StepFlow.HelpersTest.create_progression(workflow, 1)
 
       {:ok, "still_processing"} = Step.start_next(workflow)


### PR DESCRIPTION
- [x] add case no retrying status without progression
- [x] add tests to explicitly test retrying without progress